### PR TITLE
Fix: Register CommandHandler for /xget command

### DIFF
--- a/src/main/java/net/opium/blockx/Blockx.java
+++ b/src/main/java/net/opium/blockx/Blockx.java
@@ -22,6 +22,7 @@ public final class Blockx extends JavaPlugin implements Listener {
     public void onEnable() {
         getLogger().info("Blockx Plugin Enabled");
 
+        this.getCommand("xget").setExecutor(new CommandHandler(this));
         getServer().getPluginManager().registerEvents(this, this);
         createUltraCraftingTableRecipe();
     }

--- a/src/main/java/net/opium/blockx/CommandHandler.java
+++ b/src/main/java/net/opium/blockx/CommandHandler.java
@@ -25,10 +25,4 @@ public class CommandHandler implements CommandExecutor {
     private void showHelp(CommandSender sender) {
         customItems.recommendItems(sender);
     }
-
-    private void onExactCommand(CommandSender sender, String arg, String match, Runnable action) {
-        if (arg.equalsIgnoreCase(match)) {
-            action.run();
-        }
-    }
 }


### PR DESCRIPTION
The /xget command was not functioning because its CommandExecutor was not being set in the main plugin class.

This commit addresses the issue by:
- Registering `CommandHandler` for the "xget" command in `Blockx.java`'s `onEnable` method.
- Removing the unused `onExactCommand` method from `CommandHandler.java`.

With these changes, the `/xget` command and its sub-commands (like `/xget help` and `/xget <item_name>`) should now work as intended.