### PR TITLE
feat: Implement /xget summon command for heroes

### DIFF
--- a/src/main/java/net/blockx/commands/CommandHandler.java
+++ b/src/main/java/net/blockx/commands/CommandHandler.java
@@ -1,22 +1,31 @@
-package net.blockx.commands; // Updated package
+package net.blockx.commands;
 
-import net.blockx.items.CustomItem; // Updated import
-import net.blockx.items.CustomItemManager; // Updated import
+import net.blockx.core.Blockx; // Required for HeroManager and plugin instance
+import net.blockx.heroes.HeroManager;
+import net.blockx.items.CustomItem;
+import net.blockx.items.CustomItemManager;
+import net.blockx.items.CustomSwordType; // For parsing weapon names
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.inventory.ItemStack;
+// import org.bukkit.plugin.java.JavaPlugin; // No longer directly needed if Blockx instance is passed
 
 public class CommandHandler implements CommandExecutor {
 
+    private final Blockx plugin; // Store Blockx instance to access managers
     private final CustomItem customItemProvider;
-    // No longer need to store plugin or customItemManager if CustomItem is fully responsible
-    // for its dependencies once constructed. Blockx.java will pass the CIM to this constructor.
+    private final CustomItemManager customItemManager;
+    private final HeroManager heroManager;
 
-    // Constructor updated to receive CustomItemManager directly
-    public CommandHandler(JavaPlugin plugin, CustomItemManager customItemManager) {
-        // CustomItem constructor takes plugin and CIM
+    public CommandHandler(Blockx plugin, CustomItemManager customItemManager, HeroManager heroManager) {
+        this.plugin = plugin;
+        this.customItemManager = customItemManager;
+        this.heroManager = heroManager;
+        // CustomItem now takes Blockx plugin instance and CustomItemManager
         this.customItemProvider = new CustomItem(plugin, customItemManager);
     }
 
@@ -26,16 +35,69 @@ public class CommandHandler implements CommandExecutor {
             return false;
         }
 
-        if (args.length == 0) {
-            if (sender instanceof Player player) { // Use pattern matching
-                customItemProvider.showHelp(player);
-            } else {
-                sender.sendMessage("Use /xget <item_name> or see help in-game for available items.");
-            }
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "This command can only be run by a player.");
             return true;
         }
 
-        customItemProvider.handleItemCommand(args, sender);
-        return true;
+        if (args.length == 0) {
+            customItemProvider.showHelp(player);
+            return true;
+        }
+
+        String subCommand = args[0].toLowerCase();
+
+        if ("summon".equalsIgnoreCase(subCommand)) {
+            if (args.length < 2) {
+                player.sendMessage(ChatColor.RED + "Usage: /xget summon <hero_type>[:<weapon_name>]");
+                return true;
+            }
+            // args[1] should be hero_type or hero_type:weapon_name
+            handleSummonCommand(player, args);
+            return true;
+        } else {
+            // Delegate to existing item handling or help
+            customItemProvider.handleItemCommand(args, sender);
+            return true;
+        }
+    }
+
+    private void handleSummonCommand(Player player, String[] args) {
+        String heroAndWeaponArg = args[1];
+        String[] parts = heroAndWeaponArg.split(":", 2);
+        String heroType = parts[0].toLowerCase();
+        ItemStack weaponStack = null;
+
+        if (parts.length > 1) {
+            String weaponName = parts[1].toLowerCase();
+            // Attempt to parse as a CustomSwordType first
+            CustomSwordType swordType = CustomSwordType.fromString(weaponName);
+            if (swordType != null) {
+                // Generate item but don't give to player
+                weaponStack = customItemManager.generateItem(null, swordType.getCustomModelData(), swordType.getDisplayName(), swordType.getItemAttributes(), swordType.getBaseMaterial());
+            } else {
+                // Handle other specific non-sword items that can be weapons
+                // For now, let's assume barbarian_axe is a valid weapon.
+                // This part needs to be aligned with what CustomItem.java can provide.
+                // We might need a method in CustomItemManager or CustomItem to get an item by name without giving it to a player.
+                // For simplicity, directly using generateItem with null player.
+                if ("barbarian_axe".equals(weaponName)) {
+                     weaponStack = customItemManager.generateItem(null, 12301, "&cBarbarian Axe", new net.blockx.items.ItemAttributes() /* placeholder, get real attributes */, Material.IRON_AXE);
+                     // TODO: Fetch proper attributes for barbarian_axe if needed for the hero.
+                     // For now, CustomItemManager.generateItem creates it with default if attributes are complex to get here.
+                } else {
+                    player.sendMessage(ChatColor.RED + "Unknown weapon: " + weaponName);
+                    // Optional: proceed to summon hero without weapon, or return
+                    // return;
+                }
+            }
+        }
+
+        // Basic validation for heroType, expand as necessary
+        if ("zombie".equals(heroType)) { // Example: only "zombie" hero type is supported for now
+            heroManager.spawnHero(player, heroType, weaponStack);
+        } else {
+            player.sendMessage(ChatColor.RED + "Unknown hero type: " + heroType + ". Supported types: zombie");
+        }
     }
 }

--- a/src/main/java/net/blockx/core/Blockx.java
+++ b/src/main/java/net/blockx/core/Blockx.java
@@ -1,10 +1,12 @@
 package net.blockx.core;
 
+import net.blockx.abilities.AbilityManager;
 import net.blockx.abilities.BarbarianAxeAbility;
-import net.blockx.abilities.AbilityManager; // Import AbilityManager
 import net.blockx.commands.CommandHandler;
+import net.blockx.heroes.HeroManager; // Import HeroManager
 import net.blockx.items.CustomItemManager;
-import net.blockx.listeners.PlayerEventListener; // Import PlayerEventListener
+import net.blockx.listeners.HeroPickupListener; // Import HeroPickupListener
+import net.blockx.listeners.PlayerEventListener;
 
 
 import org.bukkit.Bukkit;
@@ -30,7 +32,9 @@ public final class Blockx extends JavaPlugin implements Listener {
 
     private CustomItemManager customItemManager;
     private BarbarianAxeAbility barbarianAxeAbility;
-    private AbilityManager abilityManager; // Added AbilityManager instance
+    private AbilityManager abilityManager;
+    private HeroManager heroManager; // Added HeroManager instance
+    // HeroPickupListener doesn't need to be a field if only instantiated and registered
 
     @Override
     public void onEnable() {
@@ -38,18 +42,20 @@ public final class Blockx extends JavaPlugin implements Listener {
 
         // Initialize Managers
         this.customItemManager = new CustomItemManager(this);
-        this.barbarianAxeAbility = new BarbarianAxeAbility(this, this.customItemManager);
-        this.abilityManager = new AbilityManager(this, this.customItemManager); // Initialize AbilityManager
+        this.barbarianAxeAbility = new BarbarianAxeAbility(this, this.customItemManager); // Assuming this is still needed
+        this.abilityManager = new AbilityManager(this, this.customItemManager);
+        this.heroManager = new HeroManager(this, this.customItemManager); // Initialize HeroManager
 
         // Register Command Executor
-        // CommandHandler now takes CustomItemManager directly for better dependency management
-        this.getCommand("xget").setExecutor(new CommandHandler(this, this.customItemManager));
+        // CommandHandler constructor now expects Blockx instance, CustomItemManager, and HeroManager
+        this.getCommand("xget").setExecutor(new CommandHandler(this, this.customItemManager, this.heroManager));
 
         // Register Event Listeners
-        getServer().getPluginManager().registerEvents(this, this); // For Blockx's own @EventHandlers (like crafting)
-        getServer().getPluginManager().registerEvents(new PlayerEventListener(this.abilityManager), this); // Register new PlayerEventListener
+        getServer().getPluginManager().registerEvents(this, this); // For Blockx's own @EventHandlers
+        getServer().getPluginManager().registerEvents(new PlayerEventListener(this.abilityManager), this);
+        getServer().getPluginManager().registerEvents(new HeroPickupListener(this, this.customItemManager), this); // Register HeroPickupListener
 
-        createUltraCraftingTableRecipe();
+        createUltraCraftingTableRecipe(); // Assuming this is still relevant
         getLogger().info("Blockx Systems Initialized (core package).");
     }
 

--- a/src/main/java/net/blockx/heroes/HeroManager.java
+++ b/src/main/java/net/blockx/heroes/HeroManager.java
@@ -1,0 +1,70 @@
+package net.blockx.heroes;
+
+import net.blockx.core.Blockx;
+import net.blockx.items.CustomItemManager; // We might need this later for more complex logic
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Zombie;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
+
+public class HeroManager {
+
+    private final Blockx plugin;
+    private final CustomItemManager customItemManager; // Keep for future use if needed
+
+    public static final NamespacedKey CUSTOM_HERO_TAG_KEY = new NamespacedKey("blockx", "custom_hero_type");
+
+
+    public HeroManager(Blockx plugin, CustomItemManager customItemManager) {
+        this.plugin = plugin;
+        this.customItemManager = customItemManager;
+    }
+
+    public void spawnHero(Player player, String heroType, ItemStack weapon) {
+        Location spawnLocation = player.getLocation();
+
+        // For now, we only support "zombie" as a base type.
+        // We can expand this later with a factory or strategy pattern for different hero types.
+        if (!"zombie".equalsIgnoreCase(heroType)) {
+            player.sendMessage(ChatColor.RED + "Unsupported hero type for spawning: " + heroType);
+            return;
+        }
+
+        Zombie hero = (Zombie) spawnLocation.getWorld().spawnEntity(spawnLocation, EntityType.ZOMBIE);
+
+        // Set a custom name (optional, but good for identification)
+        String heroName = "Hero " + heroType.substring(0, 1).toUpperCase() + heroType.substring(1); // e.g., "Hero Zombie"
+        if (weapon != null && weapon.hasItemMeta()) {
+            ItemMeta weaponMeta = weapon.getItemMeta();
+            if (weaponMeta != null && weaponMeta.hasDisplayName()) {
+                // Try to make a more specific name, e.g., "Barbarian Axe Wielding Zombie"
+                // We need to strip color codes from the display name for a cleaner custom name.
+                String cleanWeaponName = ChatColor.stripColor(weaponMeta.getDisplayName());
+                heroName = cleanWeaponName + " " + heroType.substring(0, 1).toUpperCase() + heroType.substring(1);
+            }
+        }
+        hero.setCustomName(ChatColor.GOLD + heroName); // Example styling
+        hero.setCustomNameVisible(true);
+
+        // Allow the hero to pick up items
+        hero.setCanPickupItems(true);
+
+        // Equip weapon if provided
+        if (weapon != null) {
+            hero.getEquipment().setItemInMainHand(weapon);
+            hero.getEquipment().setItemInMainHandDropChance(0.0f); // Don't drop the main weapon
+        }
+
+        // Tag the hero for identification by other systems (e.g., HeroPickupListener)
+        // The value could be more specific, like "zombie:barbarian_axe_wielder" if needed
+        hero.getPersistentDataContainer().set(CUSTOM_HERO_TAG_KEY, PersistentDataType.STRING, heroType);
+
+        player.sendMessage(ChatColor.GREEN + "A " + heroName + " has been summoned!");
+        plugin.getLogger().info("Spawned hero: " + heroName + " for player " + player.getName() + " with weapon: " + (weapon != null ? weapon.getType() : "none"));
+    }
+}

--- a/src/main/java/net/blockx/listeners/HeroPickupListener.java
+++ b/src/main/java/net/blockx/listeners/HeroPickupListener.java
@@ -1,0 +1,57 @@
+package net.blockx.listeners;
+
+import net.blockx.core.Blockx;
+import net.blockx.heroes.HeroManager; // For the CUSTOM_HERO_TAG_KEY
+import net.blockx.items.CustomItemManager;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Zombie;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityPickupItemEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+public class HeroPickupListener implements Listener {
+
+    private final Blockx plugin;
+    private final CustomItemManager customItemManager;
+
+    public HeroPickupListener(Blockx plugin, CustomItemManager customItemManager) {
+        this.plugin = plugin;
+        this.customItemManager = customItemManager;
+    }
+
+    @EventHandler
+    public void onHeroPickupItem(EntityPickupItemEvent event) {
+        LivingEntity entity = event.getEntity();
+
+        // Check if the entity is a Zombie (or could be any LivingEntity if heroes can be other types)
+        if (!(entity instanceof Zombie)) {
+            return; // Not a Zombie, so not one of our current heroes
+        }
+
+        PersistentDataContainer pdc = entity.getPersistentDataContainer();
+
+        // Check if the entity is tagged as one of our custom heroes
+        if (pdc.has(HeroManager.CUSTOM_HERO_TAG_KEY, PersistentDataType.STRING)) {
+            // String heroType = pdc.get(HeroManager.CUSTOM_HERO_TAG_KEY, PersistentDataType.STRING);
+            // plugin.getLogger().info("Hero (" + heroType + ") attempting to pick up: " + event.getItem().getItemStack().getType());
+
+            ItemStack itemStack = event.getItem().getItemStack();
+            String customItemId = customItemManager.getCustomItemId(itemStack);
+
+            if (customItemId != null) {
+                // This is a custom item from our plugin. Allow pickup.
+                // plugin.getLogger().info("Hero allowed to pick up custom item: " + itemStack.getType() + " (ID: " + customItemId + ")");
+                // Event is allowed by default, so no action needed here to allow it.
+            } else {
+                // This is NOT a custom item from our plugin. Prevent pickup.
+                // plugin.getLogger().info("Hero PREVENTED from picking up non-custom item: " + itemStack.getType());
+                event.setCancelled(true);
+            }
+        }
+        // If not tagged as CUSTOM_HERO_TAG_KEY, it's a regular mob, so we don't interfere with its pickup logic.
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,6 +6,6 @@ load: STARTUP
 
 commands:
   xget:
-    description: Provides custom items like the cube or shows help information.
-    usage: "/xget [<item_name>|help]"
+    description: Provides custom items, summons heroes, or shows help information.
+    usage: "/xget [<item_name>|summon <hero_type>[:<weapon_name>]|help]"
     aliases: [getx, blockxget]


### PR DESCRIPTION
Adds functionality to summon heroes (currently Zombies) using the /xget summon <hero_type>[:<weapon_name>] command.

Key changes:
- Modified CommandHandler to parse the new summon command.
- Created HeroManager to handle hero spawning, equipping weapons, and tagging heroes.
- Created HeroPickupListener to allow custom heroes to pick up custom items and prevent them from picking up non-custom items.
- Updated Blockx main plugin class to integrate new managers and listeners.
- Updated plugin.yml to reflect the new command usage.

Heroes are tagged with a PersistentDataContainer key so they can be identified by the HeroPickupListener. Standard Zombies are used as the base for heroes in this initial implementation.